### PR TITLE
SB-540: add a openshift recovery controller

### DIFF
--- a/openshift/recovery-controller/README.md
+++ b/openshift/recovery-controller/README.md
@@ -1,0 +1,67 @@
+# Spring-Boot Narayana Recovery Controller
+
+The Spring-Boot Narayana recovery controller allows to gracefully handle the scaling down phase of a StatefulSet
+by "cleaning up" pending transactions before termination.
+
+If a scaling down operation is executed and the pod is not clean after termination, the previous number of replicas is restored, 
+hence effectively cancelling the scaling down operation.
+
+All pods of the statefulset require access to a shared volume that is used to store the termination status of each pod belonging to the StatefulSet.
+
+The pod-0 of the StatefulSet periodically checks the status and scale the StatefulSet to the right size if there's a mismatch.
+
+A "edit" role on the namespace is required on Openshift in order for the pod-0 to change the number of replicas. 
+
+## Configuration
+
+Configuring Narayana to work on Openshift with the recovery controller requires special care. The following snipped shows an example of `application.properties`:
+
+```properties
+# You need to replace the following options in the Kubernetes yaml descriptor, see below
+cluster.nodename=1
+cluster.base-dir=./target/tx
+
+# TX manager
+spring.jta.transaction-manager-id=${cluster.nodename}
+spring.jta.log-dir=${cluster.base-dir}/store/${cluster.nodename}
+
+# Narayana recovery settings
+snowdrop.narayana.openshift.recovery.enabled=true
+snowdrop.narayana.openshift.recovery.current-pod-name=${cluster.nodename}
+# You must enable resource filtering in order to inject the Maven artifactId
+snowdrop.narayana.openshift.recovery.statefulset=${project.artifactId}
+snowdrop.narayana.openshift.recovery.status-dir=${cluster.base-dir}/status
+```
+
+You need a shared volume to store both transactions and termination info. It can be mounted in the statefulset yaml descriptor:
+
+```yaml
+apiVersion: apps/v1beta1
+kind: StatefulSet
+#...
+spec:
+#...
+  template:
+#...
+    spec:
+      containers:
+      - env:
+        - name: CLUSTER_BASE_DIR
+          value: /var/transaction/data
+          # Override CLUSTER_NODENAME with Kubernetes Downward API (to use `pod-0`, `pod-1` etc. as tx manager id)
+        - name: CLUSTER_NODENAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+#...
+        volumeMounts:
+        - mountPath: /var/transaction/data
+          name: the-name-of-the-shared-volume
+#...
+``` 
+
+## Camel Extension for Spring-Boot Narayana Recovery Controller 
+
+If Camel is found in the Spring-Boot application context, the Camel context is automatically stopped before 
+flushing all pending transactions.

--- a/openshift/recovery-controller/pom.xml
+++ b/openshift/recovery-controller/pom.xml
@@ -33,8 +33,9 @@
   <dependencies>
 
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter</artifactId>
+      <groupId>me.snowdrop</groupId>
+      <artifactId>spring-boot-1-narayana-starter</artifactId>
+      <version>${project.version}</version>
       <optional>true</optional>
     </dependency>
 

--- a/openshift/recovery-controller/pom.xml
+++ b/openshift/recovery-controller/pom.xml
@@ -33,15 +33,20 @@
   <dependencies>
 
     <dependency>
-      <groupId>me.snowdrop</groupId>
-      <artifactId>spring-boot-1-narayana-starter</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
       <optional>true</optional>
     </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.narayana.jta</groupId>
+      <artifactId>jta</artifactId>
       <optional>true</optional>
     </dependency>
 
@@ -54,11 +59,6 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>openshift-client</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jboss.narayana.jta</groupId>
-      <artifactId>jta</artifactId>
     </dependency>
 
   </dependencies>

--- a/openshift/recovery-controller/pom.xml
+++ b/openshift/recovery-controller/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2018 Red Hat, Inc, and individual contributors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>me.snowdrop</groupId>
+    <artifactId>spring-boot-narayana-parent</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>spring-boot-narayana-recovery-controller</artifactId>
+
+  <name>Spring Boot Narayana :: Openshift :: Recovery Controller</name>
+  <description>Spring Boot Narayana Recovery Controller for Openshift</description>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-spring-boot</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>openshift-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.narayana.jta</groupId>
+      <artifactId>jta</artifactId>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/NarayanaRecoveryTerminationController.java
+++ b/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/NarayanaRecoveryTerminationController.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.snowdrop.boot.narayana.openshift.recovery;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.arjuna.ats.arjuna.common.Uid;
+import com.arjuna.ats.arjuna.objectstore.StoreManager;
+import com.arjuna.ats.arjuna.recovery.RecoveryManager;
+import com.arjuna.ats.arjuna.state.InputObjectState;
+import com.arjuna.ats.internal.arjuna.common.UidHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Camel Narayana termination controller.
+ *
+ * @author <a href="mailto:nferraro@redhat.com">Nicola Ferraro</a>
+ */
+public class NarayanaRecoveryTerminationController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NarayanaRecoveryTerminationController.class);
+
+    private PodStatusManager podStatusManager;
+
+    private List<ServiceShutdownController> shutdownHooks;
+
+    public NarayanaRecoveryTerminationController(PodStatusManager podStatusManager, List<ServiceShutdownController> shutdownControllers) {
+        this.podStatusManager = Objects.requireNonNull(podStatusManager, "podStatusManager cannot be null");
+        this.shutdownHooks = Objects.requireNonNull(shutdownControllers, "shutdownControllers cannot be null");
+    }
+
+    public void start() {
+        LOG.info("Narayana recovery termination controller started");
+        this.podStatusManager.setStatus(PodStatus.RUNNING);
+    }
+
+    public void stop() {
+        try {
+            // Stop all services that may use transactions
+            waitForShutdownControllersToStop();
+
+            LOG.info("Performing transaction recovery scan...");
+            RecoveryManager.manager().scan();
+            LOG.info("Performing second run of transaction recovery scan...");
+            RecoveryManager.manager().scan();
+
+            List<Uid> pendingUids = getPendingUids();
+            if (pendingUids.isEmpty()) {
+                LOG.info("There are no pending transactions left");
+                this.podStatusManager.setStatus(PodStatus.STOPPED);
+            } else {
+                LOG.warn("There are pending transactions: {}", pendingUids);
+                this.podStatusManager.setStatus(PodStatus.PENDING);
+            }
+
+        } catch (Exception ex) {
+            LOG.error("Error while cleaning transaction subsystem", ex);
+        }
+    }
+
+    private void waitForShutdownControllersToStop() throws InterruptedException {
+        for (ServiceShutdownController hook : this.shutdownHooks) {
+            hook.stop();
+        }
+        LOG.info("All service shutdown hooks stopped");
+    }
+
+    private List<Uid> getPendingUids() throws Exception {
+        InputObjectState types = new InputObjectState();
+        StoreManager.getRecoveryStore().allTypes(types);
+
+        List<Uid> allUIDs = new ArrayList<>();
+        for (String typeName = types.unpackString(); typeName != null && typeName.compareTo("") != 0; typeName = types.unpackString()) {
+            List<Uid> uids = getPendingUids(typeName);
+
+            if (uids.isEmpty()) {
+                LOG.debug("Found {} UIDs for action type {}", 0, typeName);
+            } else {
+                LOG.warn("Found {} UIDs for action type {}", uids.size(), typeName);
+            }
+            allUIDs.addAll(uids);
+        }
+
+        return allUIDs;
+    }
+
+    private List<Uid> getPendingUids(String type) throws Exception {
+        List<Uid> uidList = new ArrayList<>();
+        InputObjectState uids = new InputObjectState();
+        if (!StoreManager.getRecoveryStore().allObjUids(type, uids)) {
+            throw new RuntimeException("Cannot obtain pending Uids");
+        }
+
+        if (uids.notempty()) {
+            Uid u;
+            do {
+                u = UidHelper.unpackFrom(uids);
+
+                if (Uid.nullUid().notEquals(u)) {
+                    uidList.add(u);
+                }
+            } while (Uid.nullUid().notEquals(u));
+        }
+
+        return uidList;
+    }
+
+}

--- a/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/NarayanaRecoveryTerminationControllerAutoConfiguration.java
+++ b/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/NarayanaRecoveryTerminationControllerAutoConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.snowdrop.boot.narayana.openshift.recovery;
+
+import java.util.List;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.transaction.jta.NarayanaJtaConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+
+/**
+ * Camel Narayana controller auto configuration.
+ *
+ * @author <a href="mailto:nferraro@redhat.com">Nicola Ferraro</a>
+ */
+@Configuration
+@AutoConfigureAfter({StatefulsetRecoveryControllerAutoConfiguration.class, NarayanaJtaConfiguration.class})
+@ConditionalOnBean({PodStatusManager.class})
+public class NarayanaRecoveryTerminationControllerAutoConfiguration {
+
+    @Bean(initMethod = "start", destroyMethod = "stop")
+    @DependsOn("narayanaRecoveryManagerService")
+    @ConditionalOnMissingBean(NarayanaRecoveryTerminationController.class)
+    public NarayanaRecoveryTerminationController narayanaRecoveryTerminationController(PodStatusManager podStatusManager, List<ServiceShutdownController> shutdownControllers) {
+        return new NarayanaRecoveryTerminationController(podStatusManager, shutdownControllers);
+    }
+
+}

--- a/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/NarayanaRecoveryTerminationControllerAutoConfiguration.java
+++ b/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/NarayanaRecoveryTerminationControllerAutoConfiguration.java
@@ -37,7 +37,7 @@ import org.springframework.context.annotation.DependsOn;
 public class NarayanaRecoveryTerminationControllerAutoConfiguration {
 
     @Bean(initMethod = "start", destroyMethod = "stop")
-    @DependsOn("narayanaRecoveryManagerService")
+    @DependsOn("recoveryManagerService")
     @ConditionalOnMissingBean(NarayanaRecoveryTerminationController.class)
     public NarayanaRecoveryTerminationController narayanaRecoveryTerminationController(PodStatusManager podStatusManager, List<ServiceShutdownController> shutdownControllers) {
         return new NarayanaRecoveryTerminationController(podStatusManager, shutdownControllers);

--- a/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/NarayanaRecoveryTerminationControllerAutoConfiguration.java
+++ b/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/NarayanaRecoveryTerminationControllerAutoConfiguration.java
@@ -21,7 +21,6 @@ import java.util.List;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.transaction.jta.NarayanaJtaConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
@@ -32,7 +31,11 @@ import org.springframework.context.annotation.DependsOn;
  * @author <a href="mailto:nferraro@redhat.com">Nicola Ferraro</a>
  */
 @Configuration
-@AutoConfigureAfter({StatefulsetRecoveryControllerAutoConfiguration.class, NarayanaJtaConfiguration.class})
+@AutoConfigureAfter(name = {
+        "me.snowdrop.boot.narayana.openshift.recovery.StatefulsetRecoveryControllerAutoConfiguration",
+        "me.snowdrop.boot.narayana.SpringBoot1NarayanaConfiguration",
+        "me.snowdrop.boot.narayana.SpringBoot2NarayanaConfiguration"
+})
 @ConditionalOnBean({PodStatusManager.class})
 public class NarayanaRecoveryTerminationControllerAutoConfiguration {
 

--- a/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/PodStatus.java
+++ b/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/PodStatus.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.snowdrop.boot.narayana.openshift.recovery;
+
+/**
+ * Enumerates the high level states of a pod.
+ *
+ * @author <a href="mailto:nferraro@redhat.com">Nicola Ferraro</a>
+ */
+public enum PodStatus {
+
+    /**
+     * The pod has been marked as RUNNING.
+     */
+    RUNNING,
+
+    /**
+     * The pod has terminated, but there's PENDING work to be done.
+     */
+    PENDING,
+
+    /**
+     * The pod has been gracefully STOPPED.
+     */
+    STOPPED
+}

--- a/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/PodStatusManager.java
+++ b/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/PodStatusManager.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.snowdrop.boot.narayana.openshift.recovery;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.TreeMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Manages the termination status of a pod.
+ *
+ * @author <a href="mailto:nferraro@redhat.com">Nicola Ferraro</a>
+ */
+public class PodStatusManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PodStatusManager.class);
+
+    private StatefulsetRecoveryControllerProperties properties;
+
+    public PodStatusManager(StatefulsetRecoveryControllerProperties properties) {
+        this.properties = Objects.requireNonNull(properties, "properties not set");
+        Objects.requireNonNull(properties.getStatusDir(), "statusDir has not been provided in recovery controller configuration");
+        Objects.requireNonNull(properties.getStatefulset(), "statefulset property missing in recovery controller configuration");
+        Objects.requireNonNull(properties.getCurrentPodName(), "current-pod-name property missing in recovery controller configuration");
+    }
+
+    public void setStatus(PodStatus status) {
+        this.setStatus(this.properties.getCurrentPodName(), status);
+    }
+
+    public Optional<PodStatus> getStatus() {
+        return this.getStatus(this.properties.getCurrentPodName());
+    }
+
+    public Map<String, Optional<PodStatus>> getAllPodsStatus() {
+        Map<String, Optional<PodStatus>> podStatuses = new TreeMap<>();
+
+        File baseDir = getBaseDir();
+        String[] logFiles = baseDir.list((f, name) -> name.startsWith(this.properties.getStatefulset()) && !new File(f, name).isDirectory());
+        if (logFiles == null) {
+            logFiles = new String[0];
+        }
+        for (String logFile : logFiles) {
+            Optional<PodStatus> status = getStatus(logFile);
+            podStatuses.put(logFile, status);
+        }
+
+        return podStatuses;
+    }
+
+    void setStatus(String pod, PodStatus status) {
+        File baseDir = getBaseDir();
+        File podFile = new File(baseDir, pod);
+        try (FileWriter out = new FileWriter(podFile)) {
+            out.write(status.name());
+        } catch (IOException ex) {
+            throw new RuntimeException("Cannot write status in pod file " + podFile.getAbsolutePath(), ex);
+        }
+    }
+
+    Optional<PodStatus> getStatus(String pod) {
+        File file = new File(getBaseDir(), pod);
+        try {
+            if (!file.exists()) {
+                LOG.warn("Cannot find file {} for getting the status", file.getAbsolutePath());
+                return Optional.empty();
+            }
+
+            String statusLine;
+            try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+                statusLine = reader.readLine();
+            }
+            if (statusLine != null) {
+                PodStatus status = PodStatus.valueOf(statusLine
+                        .replace("\r", "")
+                        .replace("\n", "")
+                        .trim());
+                return Optional.of(status);
+            }
+            LOG.warn("Cannot find data in file {}", file.getAbsolutePath());
+            return Optional.empty();
+        } catch (Exception ex) {
+            LOG.warn("Exception while reading file " + file.getAbsolutePath() + " for getting the status", ex);
+            return Optional.empty();
+        }
+    }
+
+    private File getBaseDir() {
+        File baseDir = new File(this.properties.getStatusDir());
+        if (!baseDir.exists() && !baseDir.mkdirs()) {
+            throw new RuntimeException("Cannot create status dir in " + this.properties.getStatusDir());
+        }
+        return baseDir;
+    }
+
+
+}

--- a/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/ServiceShutdownController.java
+++ b/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/ServiceShutdownController.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.snowdrop.boot.narayana.openshift.recovery;
+
+
+/**
+ * Beans implementing this interface and registered in the context must be shut down before starting the recovery.
+ *
+ * @author <a href="mailto:nferraro@redhat.com">Nicola Ferraro</a>
+ */
+@FunctionalInterface
+public interface ServiceShutdownController {
+
+    void stop() throws InterruptedException;
+
+}

--- a/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/StatefulsetRecoveryController.java
+++ b/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/StatefulsetRecoveryController.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.snowdrop.boot.narayana.openshift.recovery;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
+import io.fabric8.openshift.client.DefaultOpenShiftClient;
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+
+/**
+ * Executes periodic checks to ensure all terminated pods have not left unprocessed data.
+ *
+ * @author <a href="mailto:nferraro@redhat.com">Nicola Ferraro</a>
+ */
+public class StatefulsetRecoveryController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StatefulsetRecoveryController.class);
+
+    private StatefulsetRecoveryControllerProperties properties;
+
+    private PodStatusManager podStatusManager;
+
+    public StatefulsetRecoveryController(StatefulsetRecoveryControllerProperties properties, PodStatusManager podStatusManager) {
+        this.properties = Objects.requireNonNull(properties, "No properties set");
+        this.podStatusManager = Objects.requireNonNull(podStatusManager, "No podStatusManager set");
+
+        Objects.requireNonNull(properties.getStatefulset(), "statefulset property missing in recovery controller configuration");
+        Objects.requireNonNull(properties.getCurrentPodName(), "current-pod-name property missing in recovery controller configuration");
+        Objects.requireNonNull(properties.getPeriod(), "period property missing in recovery controller configuration");
+    }
+
+    @Scheduled(fixedDelayString = "${snowdrop.narayana.openshift.recovery.period:30000}", initialDelayString = "${snowdrop.narayana.openshift.recovery.period:30000}")
+    public void periodicCheck() throws Exception {
+        if (this.properties.isEnabledOnAllPods() || isMainStatefulsetPod()) {
+            // Run this on the first pod only if not configured differently
+
+            try (OpenShiftClient client = new DefaultOpenShiftClient()) {
+
+                Set<String> pendingPods = this.podStatusManager.getAllPodsStatus().entrySet().stream()
+                        .filter(e -> !Optional.of(PodStatus.STOPPED).equals(e.getValue()))
+                        .map(Map.Entry::getKey)
+                        .collect(Collectors.toSet());
+
+                LOG.debug("Found {} pods not stopped: {}", pendingPods.size(), pendingPods);
+                int minReplicas = 0;
+                for (String podName : pendingPods) {
+                    LOG.debug("Retrieving pod {} from Openshift", podName);
+                    Pod pod = client.pods().withName(podName).get();
+                    if (pod == null) {
+                        // pod has completely been removed from the cluster
+                        LOG.debug("Pod {} not found in Openshift", podName);
+                        OptionalInt prg = getProgressiveNumber(podName);
+                        if (!prg.isPresent()) {
+                            LOG.warn("Status manager contains pods not belonging to the Statefulset: {}", podName);
+                        } else {
+                            minReplicas = Math.max(minReplicas, prg.getAsInt() + 1);
+                        }
+                    } else {
+                        LOG.debug("Pod {} is running on Openshift", podName);
+                    }
+                }
+
+                LOG.debug("StatefulSet requires a minimum of {} replicas", minReplicas);
+
+                if (minReplicas > 1) {
+                    // One pod is running, this one
+                    StatefulSet statefulSet = client.apps().statefulSets().withName(this.properties.getStatefulset()).get();
+                    if (statefulSet == null) {
+                        LOG.warn("Cannot find StatefulSet named {} in namespace", this.properties.getStatefulset());
+                    } else {
+                        int replicas = statefulSet.getSpec().getReplicas();
+                        if (replicas > 0 && replicas < minReplicas) {
+                            LOG.warn("Pod {}-{} has pending work and must be restored again", this.properties.getStatefulset(), minReplicas - 1);
+
+                            LOG.debug("Scaling the statefulset back to {} replicas", minReplicas);
+                            client.apps().statefulSets().withName(this.properties.getStatefulset()).scale(minReplicas);
+                            LOG.info("Statefulset {} successfully scaled to {} replicas", this.properties.getStatefulset(), minReplicas);
+                        } else if (replicas == 0) {
+                            LOG.debug("StatefulSet {} is going to be shut down. Controller will not interfere", this.properties.getStatefulset(), replicas);
+                        } else {
+                            LOG.debug("StatefulSet {} has a sufficient number of replicas: {} >= {}", this.properties.getStatefulset(), replicas, minReplicas);
+                        }
+                    }
+                }
+            }
+
+        }
+    }
+
+    private boolean isMainStatefulsetPod() {
+        return getProgressiveNumber(this.properties.getCurrentPodName()).equals(OptionalInt.of(0));
+    }
+
+    private OptionalInt getProgressiveNumber(String podName) {
+        try {
+            return OptionalInt.of(Integer.parseInt(podName.substring(this.properties.getStatefulset().length() + 1), 10));
+        } catch (Exception e) {
+            LOG.warn("Cannot extract progressive number from pod name: " + podName);
+            return OptionalInt.empty();
+        }
+    }
+
+}

--- a/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/StatefulsetRecoveryControllerAutoConfiguration.java
+++ b/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/StatefulsetRecoveryControllerAutoConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.snowdrop.boot.narayana.openshift.recovery;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * Recovery controller spring-boot auto configuration.
+ *
+ * @author <a href="mailto:nferraro@redhat.com">Nicola Ferraro</a>
+ */
+@Configuration
+@EnableScheduling
+@EnableConfigurationProperties(StatefulsetRecoveryControllerProperties.class)
+@ConditionalOnProperty("snowdrop.narayana.openshift.recovery.enabled")
+public class StatefulsetRecoveryControllerAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(PodStatusManager.class)
+    public PodStatusManager podStatusManager(StatefulsetRecoveryControllerProperties properties) {
+        return new PodStatusManager(properties);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(StatefulsetRecoveryController.class)
+    public StatefulsetRecoveryController statefulsetRecoveryController(StatefulsetRecoveryControllerProperties properties, PodStatusManager podStatusManager) {
+        return new StatefulsetRecoveryController(properties, podStatusManager);
+    }
+
+}

--- a/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/StatefulsetRecoveryControllerProperties.java
+++ b/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/StatefulsetRecoveryControllerProperties.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.snowdrop.boot.narayana.openshift.recovery;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Recovery controller spring-boot configuration.
+ *
+ * @author <a href="mailto:nferraro@redhat.com">Nicola Ferraro</a>
+ */
+@ConfigurationProperties(prefix = "snowdrop.narayana.openshift.recovery")
+public class StatefulsetRecoveryControllerProperties {
+
+    /**
+     * Enables the recovery controller.
+     * The recovery controller runs only on pod 0 of the Statefulset by default.
+     */
+    private boolean enabled = false;
+
+    /**
+     * Enables the recovery controller on all pods, not only on pod 0 of the Statefulset.
+     */
+    private boolean enabledOnAllPods = false;
+
+    /**
+     * The delay in milliseconds between two runs of the recovery controller.
+     */
+    private long period = 30000;
+
+    /**
+     * The target statefulset to monitor.
+     */
+    private String statefulset;
+
+    /**
+     * The name of the current pod, to be filled using Kubernetes downward API.
+     */
+    private String currentPodName;
+
+    /**
+     * Path of the pod directory where pods will save their status.
+     */
+    private String statusDir;
+
+
+    public long getPeriod() {
+        return this.period;
+    }
+
+    public void setPeriod(long period) {
+        this.period = period;
+    }
+
+    public String getStatefulset() {
+        return this.statefulset;
+    }
+
+    public void setStatefulset(String statefulset) {
+        this.statefulset = statefulset;
+    }
+
+    public String getCurrentPodName() {
+        return this.currentPodName;
+    }
+
+    public void setCurrentPodName(String currentPodName) {
+        this.currentPodName = currentPodName;
+    }
+
+    public boolean isEnabled() {
+        return this.enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isEnabledOnAllPods() {
+        return this.enabledOnAllPods;
+    }
+
+    public void setEnabledOnAllPods(boolean enabledOnAllPods) {
+        this.enabledOnAllPods = enabledOnAllPods;
+    }
+
+    public String getStatusDir() {
+        return this.statusDir;
+    }
+
+    public void setStatusDir(String statusDir) {
+        this.statusDir = statusDir;
+    }
+}

--- a/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/camel/CamelServiceShutdownControllerAutoConfiguration.java
+++ b/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/camel/CamelServiceShutdownControllerAutoConfiguration.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.snowdrop.boot.narayana.openshift.recovery.camel;
+
+import me.snowdrop.boot.narayana.openshift.recovery.NarayanaRecoveryTerminationControllerAutoConfiguration;
+import me.snowdrop.boot.narayana.openshift.recovery.ServiceShutdownController;
+import org.apache.camel.CamelContext;
+import org.apache.camel.ServiceStatus;
+import org.apache.camel.spring.boot.CamelAutoConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Shutdown controller auto-configuration for the Camel context.
+ *
+ * @author <a href="mailto:nferraro@redhat.com">Nicola Ferraro</a>
+ */
+@Configuration
+@AutoConfigureAfter({CamelAutoConfiguration.class})
+@AutoConfigureBefore({NarayanaRecoveryTerminationControllerAutoConfiguration.class})
+@ConditionalOnBean({CamelContext.class})
+public class CamelServiceShutdownControllerAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(CamelServiceShutdownController.class)
+    public CamelServiceShutdownController camelShutdownHook(CamelContext camelContext) {
+        return new CamelServiceShutdownController(camelContext);
+    }
+
+    /**
+     * Waits for the Camel context to stop.
+     *
+     * @author <a href="mailto:nferraro@redhat.com">Nicola Ferraro</a>
+     */
+    public static class CamelServiceShutdownController implements ServiceShutdownController {
+
+        private static final Logger LOG = LoggerFactory.getLogger(CamelServiceShutdownController.class);
+
+        private CamelContext camelContext;
+
+        public CamelServiceShutdownController(CamelContext camelContext) {
+            this.camelContext = camelContext;
+        }
+
+        @Override
+        public void stop() throws InterruptedException {
+            LOG.info("Waiting for Camel context to stop...");
+            int attempts = 200;
+            boolean forcedShutdown = false;
+            ServiceStatus camelStatus = this.camelContext.getStatus();
+            for (int i = 0; i < attempts && !camelStatus.isStopped(); i++) {
+                if (i == 0 || forcedShutdown || camelStatus.isStopping()) {
+                    LOG.debug("Camel context still running, waiting 1 second more...");
+                } else {
+                    try {
+                        LOG.info("Forcing Camel context shutdown...");
+                        this.camelContext.stop();
+                        forcedShutdown = true;
+                    } catch (Exception ex) {
+                        LOG.warn("Unable to stop Camel context", ex);
+                    }
+                }
+
+                Thread.sleep(1000);
+                camelStatus = this.camelContext.getStatus();
+            }
+
+            if (!camelStatus.isStopped()) {
+                throw new IllegalStateException("Camel context not stopped after " + attempts + " seconds");
+            }
+            LOG.info("Camel context stopped");
+        }
+    }
+
+}

--- a/openshift/recovery-controller/src/main/resources/META-INF/spring.factories
+++ b/openshift/recovery-controller/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,4 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+me.snowdrop.boot.narayana.openshift.recovery.StatefulsetRecoveryControllerAutoConfiguration,\
+me.snowdrop.boot.narayana.openshift.recovery.NarayanaRecoveryTerminationControllerAutoConfiguration,\
+me.snowdrop.boot.narayana.openshift.recovery.camel.CamelServiceShutdownControllerAutoConfiguration

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <assertj.version>3.9.0</assertj.version>
+    <camel.version>2.20.2</camel.version>
     <checkstyle.version>8.5</checkstyle.version>
     <jboss-logging.version>3.2.1.Final</jboss-logging.version>
     <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
@@ -40,6 +41,7 @@
     <junit.version>4.12</junit.version>
     <mockito.version>2.15.0</mockito.version>
     <narayana.version>5.7.2.Final</narayana.version>
+    <openshift-client.version>3.1.8</openshift-client.version>
     <spring-boot.version>2.0.0.RELEASE</spring-boot.version>
     <spring.version>5.0.4.RELEASE</spring.version>
     <transaction-api.version>1.2</transaction-api.version>
@@ -58,6 +60,11 @@
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter</artifactId>
+        <version>${spring-boot.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-configuration-processor</artifactId>
         <version>${spring-boot.version}</version>
       </dependency>
       <dependency>
@@ -114,6 +121,16 @@
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${assertj.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>openshift-client</artifactId>
+        <version>${openshift-client.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-spring-boot</artifactId>
+        <version>${camel.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -256,5 +273,6 @@
     <module>spring-boot-1-narayana-starter</module>
     <module>spring-boot-2-narayana-starter</module>
     <module>spring-boot-narayana-starter-it</module>
+    <module>openshift/recovery-controller</module>
   </modules>
 </project>


### PR DESCRIPTION
I've adapted the recovery controller to be part of the snowdrop repo.
A quickstart using it can be found here: https://github.com/nicolaferraro/spring-boot-camel-xa.

Dependency on Camel is optional, so it can be also plugged into a pure spring-boot application.